### PR TITLE
Initial swift-driver integration

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "master",
-          "revision": "9f297a92f46027062dd798a3f1e2a61e4dcb9b81",
+          "branch": "ankit/pr",
+          "revision": "dd045701316a1bd9bdcc44c7e068c46ae8fc284e",
           "version": null
         }
       },
@@ -50,8 +50,8 @@
         "package": "llbuild2",
         "repositoryURL": "https://github.com/apple/swift-llbuild2.git",
         "state": {
-          "branch": "master",
-          "revision": "1ce4fd0333afb7dac2dfb12eceb97452bf028a17",
+          "branch": "ankit/pr",
+          "revision": "ec1d75c7e853ef04e50e33eae7eac21548bb7c14",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.0.1"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.0.1"),
-        .package(url: "https://github.com/apple/swift-llbuild2.git", .branch("master")),
-        .package(url: "https://github.com/apple/swift-driver.git", .branch("master")),
+        .package(url: "https://github.com/apple/swift-llbuild2.git", .branch("ankit/pr")),
+        .package(url: "https://github.com/apple/swift-driver.git", .branch("ankit/pr")),
         .package(url: "https://github.com/apple/swift-package-manager.git", .revision("617c8a7a8bf169830674545b721aaf72a6719328")),
 
     ],

--- a/Sources/LLBSwiftBuild/misc.swift
+++ b/Sources/LLBSwiftBuild/misc.swift
@@ -60,3 +60,10 @@ extension EventLoopFuture {
         unwrapOptional(orError: StringError(error))
     }
 }
+
+func darwinSDKPath() throws -> AbsolutePath? {
+    let result = try Process.checkNonZeroExit(
+        args: "xcrun", "-sdk", "macosx", "--show-sdk-path"
+    ).spm_chomp()
+    return AbsolutePath(result)
+}


### PR DESCRIPTION
This is minimal swift-driver integration for the executable targets
rule. The target triple is currently hardcoded to Darwin but that will
obviously change in the future.